### PR TITLE
fix: fix popup close after year month selection

### DIFF
--- a/src/components/NepaliCalendar/NepaliCalendar.module.scss
+++ b/src/components/NepaliCalendar/NepaliCalendar.module.scss
@@ -30,7 +30,7 @@
   opacity: 0.5;
 }
 
-.calendarCell:not(.calendarCellInactive) {
+.calendarCell:not(.calendarCellInactive,.calendarCellHeader) {
   cursor: pointer;
 }
 

--- a/src/components/NepaliCalendar/NepaliCalendar.tsx
+++ b/src/components/NepaliCalendar/NepaliCalendar.tsx
@@ -176,7 +176,11 @@ const NepaliCalendar: React.FC<INepaliCalendarProps> = ({
           {weekDays.map(weekShort => (
             <div
               key={weekShort}
-              className={classNames('ndt-calendar-header', styles.calendarCell)}
+              className={classNames(
+                'ndt-calendar-cell-header',
+                styles.calendarCellHeader,
+                styles.calendarCell
+              )}
             >
               {weekShort}
             </div>

--- a/src/components/NepaliDatePicker/NepaliDatePicker.tsx
+++ b/src/components/NepaliDatePicker/NepaliDatePicker.tsx
@@ -109,8 +109,12 @@ const NepaliDatePicker: React.FC<INepaliDatePickerProps> = ({
       open={isPopoverVisible}
       onOpenChange={newOpen => setIsPopoverVisible(newOpen)}
       onContentMouseDown={() => {
-        // NepaliDateInput onComplete (blur) will set this to false
+        // NepaliDateInput onComplete (blur) will use the value of isCalendarClicked (ref handleInputComplete)
         isCalendarClicked.current = true
+      }}
+      onContentBlur={() => {
+        // reset isCalendarClicked if the user leaving the calendar
+        isCalendarClicked.current = false
       }}
       onContentMouseEnter={() => reformatInputValue()}
       content={

--- a/src/components/core/Popover/Popover.tsx
+++ b/src/components/core/Popover/Popover.tsx
@@ -13,6 +13,7 @@ interface IPopoverProps {
   onOpenChange?: (newOpen: boolean) => void
   onContentMouseDown?: (event: React.MouseEvent) => void
   onContentMouseEnter?: (event: React.MouseEvent) => void
+  onContentBlur?: (event: React.FocusEvent) => void
 }
 
 const Popover: React.FC<IPopoverProps> = ({
@@ -23,16 +24,11 @@ const Popover: React.FC<IPopoverProps> = ({
   onOpenChange,
   onContentMouseDown,
   onContentMouseEnter,
+  onContentBlur,
 }) => {
   const popoverChildRef = useRef<HTMLInputElement | null>(null)
 
-  const setOpenValue = (openValue: boolean) => {
-    if (!onOpenChange) {
-      return
-    }
-
-    onOpenChange(openValue)
-  }
+  const setOpenValue = (openValue: boolean) => onOpenChange?.(openValue)
 
   return (
     <div
@@ -41,6 +37,7 @@ const Popover: React.FC<IPopoverProps> = ({
     >
       <div
         className="ndt-popover-child"
+        style={{ display: 'flex' }}
         ref={popoverChildRef}
         onClick={() => setOpenValue(true)}
       >
@@ -52,6 +49,7 @@ const Popover: React.FC<IPopoverProps> = ({
           popoverChildRef={popoverChildRef}
           onMouseDown={onContentMouseDown}
           onMouseEnter={onContentMouseEnter}
+          onBlur={onContentBlur}
         >
           {content}
         </PopoverContent>

--- a/src/components/core/Popover/PopoverContent/PopoverContent.tsx
+++ b/src/components/core/Popover/PopoverContent/PopoverContent.tsx
@@ -11,6 +11,7 @@ interface IPopoverContentProps {
   onOutsideClick?: () => void
   onMouseDown?: (event: React.MouseEvent) => void
   onMouseEnter?: (event: React.MouseEvent) => void
+  onBlur?: (event: React.FocusEvent) => void
 }
 
 const PopoverContent: React.FC<IPopoverContentProps> = ({
@@ -19,6 +20,7 @@ const PopoverContent: React.FC<IPopoverContentProps> = ({
   onOutsideClick,
   onMouseDown,
   onMouseEnter,
+  onBlur,
 }) => {
   const popupRef = useRef<HTMLDivElement | null>(null)
   const [popupStyles, setPopupStyles] = useState<React.CSSProperties>()
@@ -37,6 +39,7 @@ const PopoverContent: React.FC<IPopoverContentProps> = ({
   }, [popoverChildRef])
 
   const handleOutsideClick = useCallback(
+    // Handle if user clicks outside the Popover elements (Popover Children and Popover Content).
     (event: MouseEvent) => {
       if (!onOutsideClick) {
         return
@@ -54,12 +57,20 @@ const PopoverContent: React.FC<IPopoverContentProps> = ({
   )
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    // Handle if user changes the focus from Popover elements (Popover Children and Popover Content).
+
+    // blur event
+    onBlur?.(event)
+
     if (!onOutsideClick) {
       return
     }
 
     const relatedTarget = event.relatedTarget as Node
-    if (!popoverChildRef?.current?.contains(relatedTarget)) {
+    if (
+      !popupRef?.current?.contains(relatedTarget) &&
+      !popoverChildRef?.current?.contains(relatedTarget)
+    ) {
       onOutsideClick()
     }
   }


### PR DESCRIPTION
Development Summary:
- Checked if the focused element is not a child of the popup elements for closing the popup.
- Minor updates on cell styles.
- Reset calendarClicked value on PopoverContent blur.